### PR TITLE
Add Mobile Image Capture Source Selection

### DIFF
--- a/src/app/main/frame/frame.component.html
+++ b/src/app/main/frame/frame.component.html
@@ -8,16 +8,12 @@
     <span class="access-code">- Access Code: {{ frame.accessToken.token }}</span>
   </div>
 
-  <div class="image-upload-section">
-    <ngx-dropzone (change)="onFilesAdded($event.addedFiles)" class="image-upload-zone">
-      <ngx-dropzone-label>Drag Files or Click to Browse</ngx-dropzone-label>
-    </ngx-dropzone>
+  <ngx-dropzone (change)="onFilesAdded($event.addedFiles)" class="image-upload-zone">
+    <ngx-dropzone-label>Drag Files or Click to Browse</ngx-dropzone-label>
+  </ngx-dropzone>
 
-    <div class="image-upload-camera" *ngIf="!showImageEditor">
-      <input type="file" accept="image/*" (change)="onFilesAddedMobile($event.target.files)" [hidden]="true"
-        #fabImageUploadButton />
-      <button class="fab-image-capture" (click)="onFabClick()"><fa-icon [icon]="icons.camera"></fa-icon></button>
-    </div>
+  <div class="image-upload-camera" *ngIf="!showImageEditor">
+    <main-mobile-image-upload-fab (filesAdded)="onFilesAddedMobile($event)"></main-mobile-image-upload-fab>
   </div>
 
   <div *ngFor="let grouping of groupedImages$ | async" class="group-image-display-section">
@@ -30,11 +26,14 @@
 
   <main-live-view *ngIf="showLiveView" (exit)="onExitLiveView()"
     [accessCode]="frame.accessToken.token"></main-live-view>
-  <main-image-editor *ngIf="showImageEditor" [imageData]="imageData" (exit)="onImageEditorExit()"
-    (save)="onSaveEditedImage($event)"></main-image-editor>
 </div>
 
-<main-fullscreen-image *ngIf="selectedImageSrc !== null" [imgSrc]="selectedImageSrc" (onEscapeKeyPress)="onCloseSelectedImage()">
+
+<main-image-editor *ngIf="showImageEditor" [imageData]="imageData" (exit)="onImageEditorExit()"
+  (save)="onSaveEditedImage($event)"></main-image-editor>
+
+<main-fullscreen-image *ngIf="selectedImageSrc !== null" [imgSrc]="selectedImageSrc"
+  (onEscapeKeyPress)="onCloseSelectedImage()">
   <div class="close-fullscreen-image" (click)="onCloseSelectedImage()"><fa-icon [icon]="icons.close"
       class="clickable"></fa-icon></div>
 </main-fullscreen-image>

--- a/src/app/main/frame/frame.component.scss
+++ b/src/app/main/frame/frame.component.scss
@@ -94,24 +94,6 @@
   }
 }
 
-.fab-image-capture {
-  position: fixed;
-  bottom: 50px;
-  right: 50px;
-  z-index: 10;
-  box-shadow: 0 3px 6px rgba(0,0,0,0.5);
-  background-color: $tetradic-brown;
-  color: $light;
-  width: 60px;
-  height: 60px;
-  border-radius: 100%;
-  border: none;
-  font-size: 1.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .upload-progress {
   background-color: $success;
   height: 10px;

--- a/src/app/main/frame/frame.component.ts
+++ b/src/app/main/frame/frame.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -6,7 +6,7 @@ import { RootState } from 'src/app/root-store';
 import { FrameStoreActions, FrameStoreSelectors } from 'src/app/root-store/frame-store';
 import { GroupedImages } from 'src/app/shared/models/groupedImages';
 import { FrameModel } from 'src/app/shared/models/view-models/frameModel';
-import { faCamera, faBackspace } from '@fortawesome/free-solid-svg-icons';
+import { faBackspace } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'main-frame',
@@ -19,11 +19,9 @@ export class FrameComponent implements OnInit {
   groupedImages$ = this.setGroupedImagesSelector();
   showLiveView = false;
   icons = {
-    camera: faCamera,
     close: faBackspace
   }
   selectedImageSrc: string | null = null;
-  @ViewChild('fabImageUploadButton') fabImageUploadButton: ElementRef<HTMLInputElement>;
   showImageEditor = false;
   imageData: File;
   constructor(private store$: Store<RootState>) { }
@@ -38,10 +36,6 @@ export class FrameComponent implements OnInit {
   onFilesAddedMobile(files: FileList) {
     this.imageData = files[0];
     this.showImageEditor = true;
-  }
-
-  onFabClick() {
-    this.fabImageUploadButton.nativeElement.click();
   }
 
   onShowLiveView() {

--- a/src/app/main/main.module.ts
+++ b/src/app/main/main.module.ts
@@ -15,6 +15,7 @@ import { ImageLazyLoadDirective } from './directives/image-lazy-load.directive';
 import { ImageEditorComponent } from './image-editor/image-editor.component';
 import { ColorPickerModule } from 'ngx-color-picker';
 import { FullscreenImageComponent } from './fullscreen-image/fullscreen-image.component';
+import { MobileImageUploadFabComponent } from './mobile-image-upload-fab/mobile-image-upload-fab.component';
 
 
 
@@ -28,7 +29,8 @@ import { FullscreenImageComponent } from './fullscreen-image/fullscreen-image.co
     FrameSidenavComponent,
     ImageLazyLoadDirective,
     ImageEditorComponent,
-    FullscreenImageComponent
+    FullscreenImageComponent,
+    MobileImageUploadFabComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/main/mobile-image-upload-fab/mobile-image-upload-fab.component.html
+++ b/src/app/main/mobile-image-upload-fab/mobile-image-upload-fab.component.html
@@ -1,0 +1,9 @@
+<input type="file" accept="image/*" (change)="onFilesAdded($event.target.files)" [hidden]="true"
+    #fabImageUploadButton />
+<button class="fab-image-capture" (click)="onFabClick()"><fa-icon [icon]="cameraIcon"></fa-icon></button>
+
+<div class="image-upload-source-selector" *ngIf="showSourceSelector">
+    <div class="upload-option" (click)="selectFromCamera()">From Camera</div>
+    <div class="upload-option" (click)="selectFromSaved()">From Saved</div>
+    <div class="upload-option" (click)="cancelSelection()">Cancel</div>
+</div>

--- a/src/app/main/mobile-image-upload-fab/mobile-image-upload-fab.component.scss
+++ b/src/app/main/mobile-image-upload-fab/mobile-image-upload-fab.component.scss
@@ -1,0 +1,42 @@
+@import '../../../variables.scss';
+
+$fabBottomOffset: 50px;
+$fabRightOffset: 50px;
+$fabWidth: 60px;
+$fabHeight: 60px;
+
+.fab-image-capture {
+    position: fixed;
+    bottom: $fabBottomOffset;
+    right: $fabRightOffset;
+    z-index: 101;
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.5);
+    background-color: $tetradic-brown;
+    color: $light;
+    width: $fabWidth;
+    height: $fabHeight;
+    border-radius: 100%;
+    border: none;
+    font-size: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.image-upload-source-selector {
+    position: fixed;
+    bottom: calc(#{$fabBottomOffset} + (#{$fabHeight} / 2));
+    right: calc(#{$fabRightOffset} + #{$fabWidth});
+    background-color: $light;
+    border-radius: 8px;
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.5);
+
+    .upload-option {
+        padding: 1rem 1.5rem;
+        text-align: center;
+    }
+
+    :not(:last-child) {
+        border-bottom: 1px solid rgba(0, 0, 0, 0.5);;
+    }
+}

--- a/src/app/main/mobile-image-upload-fab/mobile-image-upload-fab.component.spec.ts
+++ b/src/app/main/mobile-image-upload-fab/mobile-image-upload-fab.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MobileImageUploadFabComponent } from './mobile-image-upload-fab.component';
+
+describe('MobileImageUploadFabComponent', () => {
+  let component: MobileImageUploadFabComponent;
+  let fixture: ComponentFixture<MobileImageUploadFabComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MobileImageUploadFabComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MobileImageUploadFabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/main/mobile-image-upload-fab/mobile-image-upload-fab.component.ts
+++ b/src/app/main/mobile-image-upload-fab/mobile-image-upload-fab.component.ts
@@ -1,0 +1,50 @@
+import { Component, ElementRef, EventEmitter, HostListener, OnInit, Output, ViewChild } from '@angular/core';
+import { faCamera } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'main-mobile-image-upload-fab',
+  templateUrl: './mobile-image-upload-fab.component.html',
+  styleUrls: ['./mobile-image-upload-fab.component.scss']
+})
+export class MobileImageUploadFabComponent implements OnInit {
+  @ViewChild('fabImageUploadButton') fabImageUploadButton: ElementRef<HTMLInputElement>;
+  @Output() filesAdded = new EventEmitter<FileList>();
+  cameraIcon = faCamera;
+  showSourceSelector = false;
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  onFilesAdded(files: FileList) {
+    this.hideSourceSelection();
+    this.filesAdded.emit(files);
+  }
+
+  onFabClick() {
+    this.showSourceSelector = true;
+  }
+
+  selectFromCamera() {
+    this.fabImageUploadButton.nativeElement.setAttribute('capture', 'environment');
+    this.initiateInputClick();
+  }
+
+  selectFromSaved() {
+    this.fabImageUploadButton.nativeElement.removeAttribute('capture');;
+    this.initiateInputClick();
+  }
+
+  cancelSelection() {
+    this.hideSourceSelection();
+  }
+
+  private initiateInputClick() {
+    this.fabImageUploadButton.nativeElement.click();
+  }
+
+  private hideSourceSelection() {
+    this.showSourceSelector = false;
+  }
+
+}


### PR DESCRIPTION
We need a capture type to dictate if a mobile user is taking a new picture or uploading an existing photo. This adds a menu upon FAB click that handles this functionality.